### PR TITLE
Fix normalization of exact term matches

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -143,7 +143,7 @@ def phenogpt_output(raw_output, biosent2vec, termDB2vec, convert2hpo = 'yes'):
             dist = []
             for j, ref in enumerate(all_terms_vec):
                 dis = distance.cosine(phenoterm, ref)
-                if dis > 0:
+                if dis >= 0:
                     all_distances[all_terms[j]] = 1 - dis
                     dist.append(1-dis)
             if len(dist) != 0:

--- a/run_phenogpt.ipynb
+++ b/run_phenogpt.ipynb
@@ -1573,7 +1573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1589,7 +1589,7 @@
     "        dist = []\n",
     "        for j, ref in enumerate(all_terms_vec):\n",
     "            dis = distance.cosine(phenoterm, ref)\n",
-    "            if dis > 0:\n",
+    "            if dis >= 0:\n",
     "                all_distances[all_terms[j]] = 1 - dis\n",
     "                dist.append(1-dis)\n",
     "        matched_pheno = list(all_distances.keys())[np.argmax(dist)]\n",


### PR DESCRIPTION
Updated "if dis > 0" to "if dis >= 0" in phenogpt_output function, in order to include exact matches with a cosine distance of 0.